### PR TITLE
Add support for pytorch dataloaders

### DIFF
--- a/examples/evaluate.py
+++ b/examples/evaluate.py
@@ -1,11 +1,11 @@
 import os
 import torch
 
-from mesmer import Mesmer
+from torch_mesmer.mesmer import Mesmer
 
-from file_utils import _load_npz
-from evaluate_utils import evaluate
-from model_utils import create_model
+from torch_mesmer.file_utils import _load_npz
+from torch_mesmer.evaluate_utils import evaluate
+from torch_mesmer.model_utils import create_model
 
 # Set torch device
 torch.cuda.empty_cache()
@@ -15,9 +15,7 @@ print(device)
 # Set data directory
 tissuenet_dir = "/data/tissuenet"
 if not os.path.exists(tissuenet_dir):
-    print("Created tissuenet data dir")
-    os.makedirs(tissuenet_dir)
-print(os.listdir(tissuenet_dir))
+    raise FileNotFoundError("Data directory does not exist")
 
 # Get evaluation data
 X_test, y_test = _load_npz(os.path.join(tissuenet_dir, "test_256x256.npz"))
@@ -37,7 +35,7 @@ model, losses, optimizer = create_model(
 )
 
 # Load saved model
-dict_save_path = "/data/saved_model_full_torch_8_best_dict.pth"
+dict_save_path = "/data/saved_model_torch_tmp_8_best_dict.pth"
 model.load_state_dict(torch.load(dict_save_path, map_location=device, weights_only=True))
 model.to(device)
 app = Mesmer(model, device=device)

--- a/examples/train_ddp.py
+++ b/examples/train_ddp.py
@@ -1,0 +1,239 @@
+import os
+import sys
+import tempfile
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.optim as optim
+import torch.multiprocessing as mp 
+from torch.nn.parallel import DistributedDataParallel as DDP
+from tqdm import tqdm
+
+import numpy as np
+ 
+from torch_mesmer.model_utils import create_model
+
+
+
+from torch_mesmer.train_utils import create_data_generators
+from torch_mesmer.file_utils import _load_npz, load_data
+
+from torch_mesmer.mesmer import mesmer_preprocess
+
+
+# On Windows platform, the torch.distributed package only
+# supports Gloo backend, FileStore and TcpStore.
+# For FileStore, set init_method parameter in init_process_group
+# to a local file. Example as follow:
+# init_method="file:///f:/libtmp/some_file"
+# dist.init_process_group(
+#    "gloo",
+#    rank=rank,
+#    init_method=init_method,
+#    world_size=world_size)
+# For TcpStore, same way as on Linux.
+
+def setup(rank, world_size):
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '12355'
+
+    # initialize the process group
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+def cleanup():
+    dist.destroy_process_group()
+
+def demo_basic(rank, world_size):
+    print(f"Running basic DDP example on rank {rank}.")
+    setup(rank, world_size)
+
+    
+    tissuenet_dir = "/data/tissuenet"
+    (X_train, y_train), (X_val, y_val) = load_data(tissuenet_dir)
+    X_test, y_test = _load_npz(os.path.join(tissuenet_dir, "test_256x256.npz"))
+
+
+    crop_size = 256
+    backbone = 'resnet50'
+    lr = 0.0001
+    # create model and move it to GPU with id rank
+    model, losses, optimizer = create_model(
+        input_shape=(crop_size, crop_size, 2),
+        backbone=backbone,
+        lr=lr,
+        device=rank,
+    ) 
+    dummy = torch.rand(3, 2, crop_size, crop_size).to(rank)
+    model = model.to(rank)
+    model(dummy)
+    
+    ddp_model = DDP(model, device_ids=[rank])
+    optimizer = torch.optim.Adam(ddp_model.parameters(), lr=lr)
+
+    smaller = 64
+    smaller_test = None
+    if smaller:
+        X_train, y_train = X_train[:smaller], y_train[:smaller]
+        X_val, y_val = X_val[:smaller], y_val[:smaller]
+    if smaller_test:
+        X_test, y_test = X_test[:smaller_test], y_test[:smaller_test]
+
+    partition = len(X_train)//world_size
+
+    if rank == (world_size-1):
+        X_train = X_train[partition*rank:]
+        y_train = y_train[partition*rank:]
+    else:
+        X_train = X_train[partition*rank:partition*(rank+1)]
+        y_train = y_train[partition*rank:partition*(rank+1)]
+
+    
+    X_train = mesmer_preprocess(X_train)
+    X_val = mesmer_preprocess(X_val)
+    
+    X_train = np.transpose(X_train, (0, 3, 1, 2))
+    y_train = np.transpose(y_train, (0, 3, 1, 2))
+    X_val = np.transpose(X_val, (0, 3, 1, 2))
+    y_val = np.transpose(y_val, (0, 3, 1, 2))
+    
+    train_dict = {"X": X_train, "y": y_train}
+    val_dict = {"X": X_val, "y": y_val}
+
+    print(train_dict["X"].shape)
+
+    seed = 0
+    zoom_min = 0.75
+    batch_size = 8
+
+    train_data, val_data = create_data_generators(
+        train_dict,
+        val_dict,
+        seed=seed,
+        zoom_min=zoom_min,
+        batch_size=batch_size,
+        crop_size=crop_size,
+        data_format="channels_first"
+    )
+
+    
+    def train_one_epoch(ddp_model):
+        running_loss_avg = 0.
+        count = 0
+
+        per_epoch_steps = len(X_train)//batch_size if len(X_train)%batch_size==0 else (len(X_train)//batch_size + 1)
+        for _ in tqdm(range(per_epoch_steps)):
+            count += 1
+            
+            li_inputs, li_labels = train_data.next()
+            
+            inputs = torch.tensor(li_inputs).to(rank)
+            labels = [torch.tensor(l).to(rank) for l in li_labels]
+
+            optimizer.zero_grad()
+
+            outputs = ddp_model(inputs)
+
+            loss = sum([losses[j](outputs[j].to(rank), labels[j].to(rank)) for j in range(len(losses))])
+
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(ddp_model.parameters(), max_norm=0.001, error_if_nonfinite=True)
+        
+            optimizer.step()
+
+            running_loss_avg += loss.item()
+            
+        return running_loss_avg/count
+    
+
+    loss_tracking = []
+    vloss_tracking = []
+    decay_scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.99)
+    plateau_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min', factor=0.33, patience=5,)
+
+    epoch_number = 0
+    start_epoch = 0
+    EPOCHS = 5
+
+    best_vloss = 1_000_000.
+    patience_count = 0
+
+    save_path_prefix = "/data/saved_model"
+    if smaller is None:
+        save_path_prefix = save_path_prefix + "_ddp_full_" + str(batch_size)
+    else:
+        save_path_prefix = save_path_prefix + "_ddp_" + str(smaller)
+
+
+    for epoch in range(start_epoch, EPOCHS):
+        print('EPOCH {}:'.format(epoch_number + 1))
+        print("TRAIN")
+        ddp_model.train(True)
+        avg_loss = train_one_epoch(ddp_model)
+        count = 0
+        
+        running_vloss_avg = 0.
+        
+        print("VAL")
+        ddp_model.eval()
+
+        per_epoch_steps = len(X_val)//batch_size if len(X_val)%batch_size==0 else (len(X_val)//batch_size + 1)
+        with torch.no_grad():
+            for _ in tqdm(range(per_epoch_steps)):
+                count += 1
+                
+                li_inputs, li_labels = val_data.next()
+
+                vinputs = torch.tensor(li_inputs).to(rank)
+                vlabels = [torch.tensor(l).to(rank) for l in li_labels]
+                
+                voutputs = ddp_model(vinputs)
+                
+                vloss = sum([losses[j](voutputs[j].to(rank), vlabels[j].to(rank)) for j in range(len(losses))])
+                    
+                running_vloss_avg += vloss
+                    
+        avg_vloss = running_vloss_avg/count
+
+        decay_scheduler.step()
+        plateau_scheduler.step(avg_vloss)
+        if rank == 0:
+            print(decay_scheduler.get_last_lr())
+        
+        loss_tracking.append(avg_loss)
+        vloss_tracking.append(avg_vloss)
+        
+        # Save model periodically
+        # TODO: figure out if you should load all as well
+        if rank == 0 and (epoch+1)%10==0:
+            epoch_path_prefix = save_path_prefix + "_epoch" + str(epoch+1)
+            dict_save_path = epoch_path_prefix + "_dict.pth"            
+            torch.save(ddp_model.module.state_dict(), dict_save_path)
+        
+        if rank == 0 and avg_vloss<best_vloss:
+            best_vloss = avg_vloss
+            dict_save_path = save_path_prefix + "_best_dict.pth"            
+            torch.save(ddp_model.module.state_dict(), dict_save_path)
+
+            patience_count = 0
+        elif rank == 0:
+            patience_count += 1
+
+        if rank == 0: 
+            print('LOSS train {} valid {}'.format(avg_loss, avg_vloss))
+
+        epoch_number += 1
+
+        if patience_count >= 10:
+            break
+
+    cleanup()
+    print(f"Finished running basic DDP example on rank {rank}.")
+
+
+def run_demo(demo_fn, world_size):
+    mp.spawn(demo_fn,
+             args=(world_size,),
+             nprocs=world_size,
+             join=True)
+if __name__ == '__main__':
+    run_demo(demo_basic, 2)

--- a/examples/train_torch.py
+++ b/examples/train_torch.py
@@ -1,14 +1,20 @@
 import os
+
+import time
+from tqdm import tqdm
+
 import numpy as np
 import torch
 import torch.nn as nn
-import time
+from torch.utils.data import Dataset, DataLoader
 
-from tqdm import tqdm
+from torch_mesmer.file_utils import _load_npz, load_data
+from torch_mesmer.model_utils import create_model
 
-from mesmer import mesmer_preprocess
-from iter_semantic import SemanticDataGenerator
-from iter_cropping import CroppingDataGenerator
+from torch_mesmer.mesmer import mesmer_preprocess
+
+from torch_mesmer.loader_utils import SemanticDataset
+from torch_mesmer.loader_utils import CroppingDatasetTorch
 
 torch.cuda.empty_cache()
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -16,13 +22,7 @@ print(device)
 
 tissuenet_dir = "/data/tissuenet"
 if not os.path.exists(tissuenet_dir):
-    print("Created tissuenet data dir")
-    os.makedirs(tissuenet_dir)
-
-print(os.listdir(tissuenet_dir))
-
-from file_utils import _load_npz, load_data
-from model_utils import create_model
+    raise FileNotFoundError("Data directory does not exist")
 
 # instantiate model
 crop_size = 256
@@ -37,29 +37,21 @@ model, losses, optimizer = create_model(
 dummy = torch.rand(3, 2, crop_size, crop_size).to(device)
 model(dummy)
 
-from train_utils import create_data_generators
-from loader_utils import SemanticDataset
-from loader_utils import CroppingDatasetTorch
-
 seed = 0
 zoom_min = 0.75
 batch_size = 8
 
 (X_train, y_train), (X_val, y_val) = load_data(tissuenet_dir)
 
-smaller = None
+smaller = 512
 if smaller:
     X_train, y_train = X_train[:smaller], y_train[:smaller]
     X_val, y_val = X_val[:smaller], y_val[:smaller]
 
-# train_dict = {"X": mesmer_preprocess(X_train), "y": y_train}
-# val_dict = {"X": mesmer_preprocess(X_val), "y": y_val}
-
+print("Preprocess: Start")
 X_train = mesmer_preprocess(X_train)
-print("train preprocess: done")
-
 X_val = mesmer_preprocess(X_val)
-print("val preprocess: done")
+print("Preprocess: End")
 
 rotation_range = 180
 shear_range = 0
@@ -72,57 +64,29 @@ transforms_kwargs={
     "pixelwise": {"dilation_radius": 1},
     "inner-distance": {"erosion_width": 1, "alpha": "auto"},
 }
-from torch.utils.data import Dataset, DataLoader
 
 cdt = CroppingDatasetTorch(X_train, y_train, rotation_range, shear_range, zoom_range, horizontal_flip, vertical_flip, crop_size, batch_size=batch_size, transforms=transforms, transforms_kwargs=transforms_kwargs)
 
-dataloader = DataLoader(cdt, batch_size=batch_size, shuffle=True, num_workers=4)
+dataloader = DataLoader(cdt, batch_size=batch_size, shuffle=True, pin_memory=True, num_workers=4)
 dataiter = iter(dataloader)
 X_sd, y_sd = next(dataiter)
 print(X_sd.shape)
 print(len(y_sd))
 print(y_sd[3].shape)
 
-
-X_train = np.transpose(X_train, (0, 3, 1, 2))
-y_train = np.transpose(y_train, (0, 3, 1, 2))
-X_val = np.transpose(X_val, (0, 3, 1, 2))
-y_val = np.transpose(y_val, (0, 3, 1, 2))
+# X_val = np.transpose(X_val, (0, 3, 1, 2))
+# y_val = np.transpose(y_val, (0, 3, 1, 2))
 sd = SemanticDataset(X_val, y_val, transforms=transforms, transforms_kwargs=transforms_kwargs)
 valloader = DataLoader(sd, batch_size=batch_size, shuffle=False, num_workers=4)
 
-
-train_dict = {"X": X_train, "y": y_train}
-val_dict = {"X": X_val, "y": y_val}
-
-train_data, val_data = create_data_generators(
-    train_dict,
-    val_dict,
-    seed=seed,
-    zoom_min=zoom_min,
-    batch_size=batch_size,
-    crop_size=crop_size,
-    data_format="channels_first"
-)
-
-inputs, labels = train_data.next()
-print(inputs.shape)
-print(len(labels))
-print(labels[3].shape)
 
 def train_one_epoch(model):
     running_loss_avg = 0.
     count = 0
 
-    per_epoch_steps = len(X_train)//batch_size if len(X_train)%batch_size==0 else (len(X_train)//batch_size + 1)
-    # dataloader = DataLoader(cdt, batch_size=batch_size, shuffle=True, num_workers=4)
     for (li_inputs, li_labels) in tqdm(dataloader):
-
-    # for _ in tqdm(range(per_epoch_steps)):
         count += 1
-        
-        # li_inputs, li_labels = next(dataiter)
-        
+                
         inputs = li_inputs.to(device)
         labels = [l.to(device) for l in li_labels]
 
@@ -148,7 +112,7 @@ plateau_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min',
 
 epoch_number = 0
 start_epoch = 0
-EPOCHS = 100
+EPOCHS = 5
 
 best_vloss = 1_000_000.
 patience_count = 0
@@ -157,14 +121,14 @@ model = model.to(device)
 
 save_path_prefix = "/data/saved_model"
 if smaller is None:
-    save_path_prefix = save_path_prefix + "_full_torch_" + str(batch_size)
+    save_path_prefix = save_path_prefix + "_torch_tmp_" + str(batch_size)
 else:
     save_path_prefix = save_path_prefix + "_" + str(smaller)
 
 for epoch in range(start_epoch, EPOCHS):
     print('EPOCH {}:'.format(epoch_number + 1))
     print("TRAIN")
-    model.train(True)
+    model.train()
     avg_loss = train_one_epoch(model)
     count = 0
     
@@ -173,14 +137,10 @@ for epoch in range(start_epoch, EPOCHS):
     print("VAL")
     model.eval()
 
-    per_epoch_steps = len(X_val)//batch_size if len(X_val)%batch_size==0 else (len(X_val)//batch_size + 1)
     with torch.no_grad():
         for (li_inputs, li_labels) in tqdm(valloader):
-        # for _ in tqdm(range(per_epoch_steps)):
             count += 1
             
-            # li_inputs, li_labels = val_data.next()
-
             vinputs = li_inputs.to(device)
             vlabels = [l.to(device) for l in li_labels]
             
@@ -203,18 +163,14 @@ for epoch in range(start_epoch, EPOCHS):
     if (epoch+1)%10==0:
         epoch_path_prefix = save_path_prefix + "_epoch" + str(epoch+1)
         dict_save_path = epoch_path_prefix + "_dict.pth"
-        save_path = epoch_path_prefix + ".pth"
         
         torch.save(model.state_dict(), dict_save_path)
-        # torch.save(model, save_path)
     
     if avg_vloss<best_vloss:
         best_vloss = avg_vloss
         dict_save_path = save_path_prefix + "_best_dict.pth"
-        save_path = save_path_prefix + ".pth"
         
         torch.save(model.state_dict(), dict_save_path)
-        # torch.save(model, save_path)
         patience_count = 0
     else:
         patience_count += 1

--- a/torch_mesmer/iter_cropping.py
+++ b/torch_mesmer/iter_cropping.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from tensorflow.keras.preprocessing.image import array_to_img
 
-from iter_semantic import SemanticDataGenerator, SemanticIterator
+from .iter_semantic import SemanticDataGenerator, SemanticIterator
 
 try:
     import scipy

--- a/torch_mesmer/mask_utils.py
+++ b/torch_mesmer/mask_utils.py
@@ -1,0 +1,261 @@
+import numpy as np
+import warnings
+
+from .transform_utils import pixelwise_transform
+from .transform_utils import outer_distance_transform_movie, outer_distance_transform_3d, outer_distance_transform_2d
+from .transform_utils import inner_distance_transform_movie, inner_distance_transform_3d, inner_distance_transform_2d
+
+def to_categorical(x, num_classes=None):
+    """Converts a class vector (integers) to binary class matrix.
+
+    E.g. for use with `categorical_crossentropy`.
+
+    Args:
+        x: Array-like with class values to be converted into a matrix
+            (integers from 0 to `num_classes - 1`).
+        num_classes: Total number of classes. If `None`, this would be inferred
+            as `max(x) + 1`. Defaults to `None`.
+
+    Returns:
+        A binary matrix representation of the input as a NumPy array. The class
+        axis is placed last.
+
+    Example:
+
+    >>> a = keras.utils.to_categorical([0, 1, 2, 3], num_classes=4)
+    >>> print(a)
+    [[1. 0. 0. 0.]
+     [0. 1. 0. 0.]
+     [0. 0. 1. 0.]
+     [0. 0. 0. 1.]]
+
+    >>> b = np.array([.9, .04, .03, .03,
+    ...               .3, .45, .15, .13,
+    ...               .04, .01, .94, .05,
+    ...               .12, .21, .5, .17],
+    ...               shape=[4, 4])
+    >>> loss = keras.ops.categorical_crossentropy(a, b)
+    >>> print(np.around(loss, 5))
+    [0.10536 0.82807 0.1011  1.77196]
+
+    >>> loss = keras.ops.categorical_crossentropy(a, a)
+    >>> print(np.around(loss, 5))
+    [0. 0. 0. 0.]
+    """
+    x = np.array(x, dtype="int64")
+    input_shape = x.shape
+
+    # Shrink the last dimension if the shape is (..., 1).
+    if input_shape and input_shape[-1] == 1 and len(input_shape) > 1:
+        input_shape = tuple(input_shape[:-1])
+
+    x = x.reshape(-1)
+    if not num_classes:
+        num_classes = np.max(x) + 1
+    batch_size = x.shape[0]
+    categorical = np.zeros((batch_size, num_classes))
+    categorical[np.arange(batch_size), x] = 1
+    output_shape = input_shape + (num_classes,)
+    categorical = np.reshape(categorical, output_shape)
+    return categorical
+
+
+def _transform_masks(y, transform, data_format=None, **kwargs):
+    """Based on the transform key, apply a transform function to the masks.
+
+    Refer to :mod:`deepcell.utils.transform_utils` for more information about
+    available transforms. Caution for unknown transform keys.
+
+    Args:
+        y (numpy.array): Labels of ``ndim`` 4 or 5
+        transform (str): Name of the transform, one of
+            ``{"deepcell", "disc", "watershed", None}``.
+        data_format (str): A string, one of ``channels_last`` (default)
+            or ``channels_first``. The ordering of the dimensions in the
+            inputs. ``channels_last`` corresponds to inputs with shape
+            ``(batch, height, width, channels)`` while ``channels_first``
+            corresponds to inputs with shape
+            ``(batch, channels, height, width)``.
+        kwargs (dict): Optional transform keyword arguments.
+
+    Returns:
+        numpy.array: the output of the given transform function on ``y``.
+
+    Raises:
+        ValueError: Rank of ``y`` is not 4 or 5.
+        ValueError: Channel dimension of ``y`` is not 1.
+        ValueError: ``transform`` is invalid value.
+    """
+    valid_transforms = {
+        'deepcell',  # deprecated for "pixelwise"
+        'pixelwise',
+        'disc',
+        'watershed',  # deprecated for "outer-distance"
+        'watershed-cont',  # deprecated for "outer-distance"
+        'inner-distance', 'inner_distance',
+        'outer-distance', 'outer_distance',
+        'centroid',  # deprecated for "inner-distance"
+        'fgbg'
+    }
+    if data_format is None:
+        data_format = "channels_last"
+
+    if y.ndim not in {4, 5}:
+        raise ValueError('`labels` data must be of ndim 4 or 5.  Got', y.ndim)
+
+    channel_axis = 1 if data_format == 'channels_first' else -1
+
+    if y.shape[channel_axis] != 1:
+        raise ValueError('Expected channel axis to be 1 dimension. Got',
+                         y.shape[1 if data_format == 'channels_first' else -1])
+
+    if isinstance(transform, str):
+        transform = transform.lower()
+
+    if transform not in valid_transforms and transform is not None:
+        raise ValueError(f'`{transform}` is not a valid transform')
+
+    if transform in {'pixelwise', 'deepcell'}:
+        if transform == 'deepcell':
+            warnings.warn(f'The `{transform}` transform is deprecated. Please use the '
+                          '`pixelwise` transform instead.',
+                          DeprecationWarning)
+        dilation_radius = kwargs.pop('dilation_radius', None)
+        separate_edge_classes = kwargs.pop('separate_edge_classes', False)
+
+        edge_class_shape = 4 if separate_edge_classes else 3
+
+        if data_format == 'channels_first':
+            shape = tuple([y.shape[0]] + [edge_class_shape] + list(y.shape[2:]))
+        else:
+            shape = tuple(list(y.shape[0:-1]) + [edge_class_shape])
+
+        # using uint8 since should only be 4 unique values.
+        y_transform = np.zeros(shape, dtype=np.uint8)
+
+        for batch in range(y_transform.shape[0]):
+            if data_format == 'channels_first':
+                mask = y[batch, 0, ...]
+            else:
+                mask = y[batch, ..., 0]
+
+            y_transform[batch] = pixelwise_transform(
+                mask, dilation_radius, data_format=data_format,
+                separate_edge_classes=separate_edge_classes)
+
+    elif transform in {'outer-distance', 'outer_distance',
+                       'watershed', 'watershed-cont'}:
+        if transform in {'watershed', 'watershed-cont'}:
+            warnings.warn(f'The `{transform}` transform is deprecated. Please use the '
+                          '`outer-distance` transform instead.',
+                          DeprecationWarning)
+
+        by_frame = kwargs.pop('by_frame', True)
+        bins = kwargs.pop('distance_bins', None)
+
+        distance_kwargs = {
+            'bins': bins,
+            'erosion_width': kwargs.pop('erosion_width', 0),
+        }
+
+        # If using 3d transform, pass in scale arg
+        if y.ndim == 5 and not by_frame:
+            distance_kwargs['sampling'] = kwargs.pop('sampling', [0.5, 0.217, 0.217])
+
+        if data_format == 'channels_first':
+            shape = tuple([y.shape[0]] + list(y.shape[2:]))
+        else:
+            shape = y.shape[0:-1]
+        y_transform = np.zeros(shape, dtype=np.float32)
+
+        if y.ndim == 5:
+            if by_frame:
+                _distance_transform = outer_distance_transform_movie
+            else:
+                _distance_transform = outer_distance_transform_3d
+        else:
+            _distance_transform = outer_distance_transform_2d
+
+        for batch in range(y_transform.shape[0]):
+            if data_format == 'channels_first':
+                mask = y[batch, 0, ...]
+            else:
+                mask = y[batch, ..., 0]
+            y_transform[batch] = _distance_transform(mask, **distance_kwargs)
+
+        y_transform = np.expand_dims(y_transform, axis=-1)
+
+        if bins is not None:
+            # convert to one hot notation
+            # uint8's max value of255 seems like a generous limit for binning.
+            y_transform = to_categorical(y_transform, num_classes=bins, dtype=np.uint8)
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
+
+    elif transform in {'inner-distance', 'inner_distance', 'centroid'}:
+        if transform == 'centroid':
+            warnings.warn(f'The `{transform}` transform is deprecated. Please use the '
+                          '`inner-distance` transform instead.',
+                          DeprecationWarning)
+
+        by_frame = kwargs.pop('by_frame', True)
+        bins = kwargs.pop('distance_bins', None)
+
+        distance_kwargs = {
+            'bins': bins,
+            'erosion_width': kwargs.pop('erosion_width', 0),
+            'alpha': kwargs.pop('alpha', 0.1),
+            'beta': kwargs.pop('beta', 1)
+        }
+
+        # If using 3d transform, pass in scale arg
+        if y.ndim == 5 and not by_frame:
+            distance_kwargs['sampling'] = kwargs.pop('sampling', [0.5, 0.217, 0.217])
+
+        if data_format == 'channels_first':
+            shape = tuple([y.shape[0]] + list(y.shape[2:]))
+        else:
+            shape = y.shape[0:-1]
+        y_transform = np.zeros(shape, dtype=np.float32)
+
+        if y.ndim == 5:
+            if by_frame:
+                _distance_transform = inner_distance_transform_movie
+            else:
+                _distance_transform = inner_distance_transform_3d
+        else:
+            _distance_transform = inner_distance_transform_2d
+
+        for batch in range(y_transform.shape[0]):
+            if data_format == 'channels_first':
+                mask = y[batch, 0, ...]
+            else:
+                mask = y[batch, ..., 0]
+            y_transform[batch] = _distance_transform(mask, **distance_kwargs)
+
+        y_transform = np.expand_dims(y_transform, axis=-1)
+
+        if distance_kwargs['bins'] is not None:
+            # convert to one hot notation
+            # uint8's max value of255 seems like a generous limit for binning.
+            y_transform = to_categorical(y_transform, num_classes=bins, dtype=np.uint8)
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
+
+    elif transform == 'disc' or transform is None:
+        dtype = np.float32 if transform == 'disc' else np.int32
+        y_transform = to_categorical(y.squeeze(channel_axis), dtype=dtype)
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
+
+    elif transform == 'fgbg':
+        y_transform = np.where(y > 1, 1, y)
+        # convert to one hot notation
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, 1, y.ndim)
+        # using uint8 since should only be 2 unique values.
+        y_transform = to_categorical(y_transform, dtype=np.uint8)
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
+
+    return y_transform

--- a/torch_mesmer/train_utils.py
+++ b/torch_mesmer/train_utils.py
@@ -1,5 +1,5 @@
-from iter_semantic import SemanticDataGenerator
-from iter_cropping import CroppingDataGenerator
+from .iter_semantic import SemanticDataGenerator
+from .iter_cropping import CroppingDataGenerator
 
 def create_data_generators(
     train_dict,

--- a/torch_mesmer/transform_utils.py
+++ b/torch_mesmer/transform_utils.py
@@ -1,0 +1,403 @@
+import numpy as np
+
+from scipy import ndimage
+from skimage.measure import label
+from skimage.measure import regionprops
+from skimage.morphology import ball, disk
+from skimage.morphology import binary_dilation
+from skimage.segmentation import find_boundaries
+
+from .toolbox_utils import erode_edges
+
+eps = 1e-7
+
+def pixelwise_transform(mask, dilation_radius=None, data_format=None,
+                        separate_edge_classes=False):
+    """Transforms a label mask for a z stack edge, interior, and background
+
+    Args:
+        mask (numpy.array): tensor of labels
+        dilation_radius (int):  width to enlarge the edge feature of
+            each instance
+        data_format (str): A string, one of ``channels_last`` (default)
+            or ``channels_first``. The ordering of the dimensions in the
+            inputs. ``channels_last`` corresponds to inputs with shape
+            ``(batch, height, width, channels)`` while ``channels_first``
+            corresponds to inputs with shape
+            ``(batch, channels, height, width)``.
+        separate_edge_classes (bool): Whether to separate the cell edge class
+            into 2 distinct cell-cell edge and cell-background edge classes.
+
+    Returns:
+        numpy.array: An array with the same shape as ``mask``, except the
+        channel axis will be a one-hot encoded semantic segmentation for
+        3 main features:
+        ``[cell_edge, cell_interior, background]``.
+        If ``separate_edge_classes`` is ``True``, the ``cell_interior``
+        feature is split into 2 features and the resulting channels are:
+        ``[bg_cell_edge, cell_cell_edge, cell_interior, background]``.
+    """
+    if data_format is None:
+        print("Please provide a data format")
+        assert(False)
+
+    if data_format == 'channels_first':
+        channel_axis = 0
+    else:
+        channel_axis = -1
+
+    # Detect the edges and interiors
+    edge = find_boundaries(mask, mode='inner').astype('int')
+    interior = np.logical_and(edge == 0, mask > 0).astype('int')
+
+    strel = ball(1) if mask.ndim > 2 else disk(1)
+    if not separate_edge_classes:
+        if dilation_radius:
+            dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
+            # Thicken cell edges to be more pronounced
+            edge = binary_dilation(edge, footprint=dil_strel)
+
+            # Thin the augmented edges by subtracting the interior features.
+            edge = (edge - interior > 0).astype('int')
+
+        background = (1 - edge - interior > 0)
+        background = background.astype('int')
+
+        all_stacks = [
+            edge,
+            interior,
+            background
+        ]
+
+        return np.stack(all_stacks, axis=channel_axis)
+
+    # dilate the background masks and subtract from all edges for background-edges
+    background = (mask == 0).astype('int')
+    dilated_background = binary_dilation(background, strel)
+
+    background_edge = (edge - dilated_background > 0).astype('int')
+
+    # edges that are not background-edges are interior-edges
+    interior_edge = (edge - background_edge > 0).astype('int')
+
+    if dilation_radius:
+        dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
+        # Thicken cell edges to be more pronounced
+        interior_edge = binary_dilation(interior_edge, footprint=dil_strel)
+        background_edge = binary_dilation(background_edge, footprint=dil_strel)
+
+        # Thin the augmented edges by subtracting the interior features.
+        interior_edge = (interior_edge - interior > 0).astype('int')
+        background_edge = (background_edge - interior > 0).astype('int')
+
+    background = (1 - background_edge - interior_edge - interior > 0)
+    background = background.astype('int')
+
+    all_stacks = [
+        background_edge,
+        interior_edge,
+        interior,
+        background
+    ]
+
+    return np.stack(all_stacks, axis=channel_axis)
+
+
+def outer_distance_transform_2d(mask, bins=None, erosion_width=None,
+                                normalize=True):
+    """Transform a label mask with an outer distance transform.
+
+    Args:
+        mask (numpy.array): A label mask (``y`` data).
+        bins (int): The number of transformed distance classes. If ``None``,
+            returns the continuous outer transform.
+        erosion_width (int): Number of pixels to erode edges of each labels
+        normalize (bool): Normalize the transform of each cell by that
+            cell's largest distance.
+
+    Returns:
+        numpy.array: A mask of same shape as input mask,
+        with each label being a distance class from 1 to ``bins``.
+    """
+    mask = np.squeeze(mask)  # squeeze the channels
+    mask = erode_edges(mask, erosion_width)
+
+    distance = ndimage.distance_transform_edt(mask)
+    distance = distance.astype(np.float32)  # normalized distances are floats
+
+    if normalize:
+        # uniquely label each cell and normalize the distance values
+        # by that cells maximum distance value
+        label_matrix = label(mask)
+        for prop in regionprops(label_matrix):
+            labeled_distance = distance[label_matrix == prop.label]
+            normalized_distance = labeled_distance / np.amax(labeled_distance)
+            distance[label_matrix == prop.label] = normalized_distance
+
+    if bins is None:
+        return distance
+
+    # bin each distance value into a class from 1 to bins
+    min_dist = np.amin(distance)
+    max_dist = np.amax(distance)
+    distance_bins = np.linspace(min_dist - eps,
+                                max_dist + eps,
+                                num=bins + 1)
+    distance = np.digitize(distance, distance_bins, right=True)
+    return distance - 1  # minimum distance should be 0, not 1
+
+
+def outer_distance_transform_3d(mask, bins=None, erosion_width=None,
+                                normalize=True, sampling=[0.5, 0.217, 0.217]):
+    """Transforms a label mask for a z stack with an outer distance transform.
+    Uses scipy's distance_transform_edt
+
+    Args:
+        mask (numpy.array): A z-stack of label masks (``y`` data).
+        bins (int): The number of transformed distance classes.
+        erosion_width (int): Number of pixels to erode edges of each labels.
+        normalize (bool): Normalize the transform of each cell by that
+            cell's largest distance.
+        sampling (list): Spacing of pixels along each dimension.
+
+    Returns:
+        numpy.array: 3D Euclidiean Distance Transform
+    """
+    maskstack = np.squeeze(mask)  # squeeze the channels
+    maskstack = erode_edges(maskstack, erosion_width)
+
+    distance = ndimage.distance_transform_edt(maskstack, sampling=sampling)
+
+    # normalize by maximum distance
+    if normalize:
+        for cell_label in np.unique(maskstack):
+            if cell_label == 0:  # distance is only found for non-zero regions
+                continue
+            index = np.nonzero(maskstack == cell_label)
+            distance[index] = distance[index] / np.amax(distance[index])
+
+    if bins is None:
+        return distance
+
+    # divide into bins
+    min_dist = np.amin(distance.flatten())
+    max_dist = np.amax(distance.flatten())
+    distance_bins = np.linspace(min_dist - eps,
+                                max_dist + eps,
+                                num=bins + 1)
+    distance = np.digitize(distance, distance_bins, right=True)
+    return distance - 1  # minimum distance should be 0, not 1
+
+
+def outer_distance_transform_movie(mask, bins=None, erosion_width=None,
+                                   normalize=True):
+    """Transform a label mask for a movie with an outer distance transform.
+    Applies the 2D transform to each frame.
+
+    Args:
+        mask (numpy.array): A label mask (``y`` data).
+        bins (int): The number of transformed distance classes.
+        erosion_width (int): number of pixels to erode edges of each labels.
+        normalize (bool): Normalize the transform of each cell by that
+            cell's largest distance.
+
+    Returns:
+        numpy.array: a mask of same shape as input mask,
+        with each label being a distance class from 1 to ``bins``
+    """
+    distances = []
+    for frame in range(mask.shape[0]):
+        mask_frame = mask[frame]
+
+        distance = outer_distance_transform_2d(
+            mask_frame, bins=bins,
+            erosion_width=erosion_width,
+            normalize=normalize)
+
+        distances.append(distance)
+
+    distances = np.stack(distances, axis=0)
+
+    return distances
+
+
+def inner_distance_transform_2d(mask, bins=None, erosion_width=None,
+                                alpha=0.1, beta=1):
+    """Transform a label mask with an inner distance transform.
+
+    .. code-block:: python
+
+        inner_distance = 1 / (1 + beta * alpha * distance_to_center)
+
+    Args:
+        mask (numpy.array): A label mask (``y`` data).
+        bins (int): The number of transformed distance classes.
+        erosion_width (int): number of pixels to erode edges of each labels
+        alpha (float, str): coefficent to reduce the magnitude of the distance
+            value. If "auto", determines ``alpha`` for each cell based on the
+            cell area.
+        beta (float): scale parameter that is used when ``alpha`` is "auto".
+
+    Returns:
+        numpy.array: a mask of same shape as input mask,
+        with each label being a distance class from 1 to ``bins``.
+
+    Raises:
+        ValueError: ``alpha`` is a string but not set to "auto".
+    """
+    # Check input to alpha
+    if isinstance(alpha, str):
+        if alpha.lower() != 'auto':
+            raise ValueError('alpha must be set to "auto"')
+
+    mask = np.squeeze(mask)
+    mask = erode_edges(mask, erosion_width)
+
+    distance = ndimage.distance_transform_edt(mask)
+    distance = distance.astype(np.float32)
+
+    label_matrix = label(mask)
+
+    inner_distance = np.zeros(distance.shape, dtype=np.float32)
+    for prop in regionprops(label_matrix, distance):
+        coords = prop.coords
+        center = prop.weighted_centroid
+        distance_to_center = np.sum((coords - center) ** 2, axis=1)
+
+        # Determine alpha to use
+        if str(alpha).lower() == 'auto':
+            _alpha = 1 / np.sqrt(prop.area)
+        else:
+            _alpha = float(alpha)
+
+        center_transform = 1 / (1 + beta * _alpha * distance_to_center)
+        coords_x = coords[:, 0]
+        coords_y = coords[:, 1]
+        inner_distance[coords_x, coords_y] = center_transform
+
+    if bins is None:
+        return inner_distance
+
+    # divide into bins
+    min_dist = np.amin(inner_distance.flatten())
+    max_dist = np.amax(inner_distance.flatten())
+    distance_bins = np.linspace(min_dist - eps,
+                                max_dist + eps,
+                                num=bins + 1)
+    inner_distance = np.digitize(inner_distance, distance_bins, right=True)
+    return inner_distance - 1  # minimum distance should be 0, not 1
+
+
+def inner_distance_transform_3d(mask, bins=None,
+                                erosion_width=None,
+                                alpha=0.1, beta=1,
+                                sampling=[0.5, 0.217, 0.217]):
+    """Transform a label mask for a z-stack with an inner distance transform.
+
+    .. code-block:: python
+
+        inner_distance = 1 / (1 + beta * alpha * distance_to_center)
+
+    Args:
+        mask (numpy.array): A label mask (``y`` data).
+        bins (int): The number of transformed distance classes.
+        erosion_width (int): Number of pixels to erode edges of each labels
+        alpha (float, str): Coefficent to reduce the magnitude of the distance
+            value. If ``'auto'``, determines alpha for each cell based on the
+            cell area.
+        beta (float): Scale parameter that is used when ``alpha`` is "auto".
+        sampling (list): Spacing of pixels along each dimension.
+
+    Returns:
+        numpy.array: A mask of same shape as input mask,
+        with each label being a distance class from 1 to ``bins``.
+
+    Raises:
+        ValueError: ``alpha`` is a string but not set to "auto".
+    """
+    # Check input to alpha
+    if isinstance(alpha, str):
+        if alpha.lower() != 'auto':
+            raise ValueError('alpha must be set to "auto"')
+
+    mask = np.squeeze(mask)
+    mask = erode_edges(mask, erosion_width)
+
+    distance = ndimage.distance_transform_edt(mask, sampling=sampling)
+    distance = distance.astype(np.float32)
+
+    label_matrix = label(mask)
+
+    inner_distance = np.zeros(distance.shape, dtype=np.float32)
+    for prop in regionprops(label_matrix, distance):
+        coords = prop.coords
+        center = prop.weighted_centroid
+        distance_to_center = (coords - center) * np.array(sampling)
+        distance_to_center = np.sum(distance_to_center ** 2, axis=1)
+
+        # Determine alpha to use
+        if str(alpha).lower() == 'auto':
+            _alpha = 1 / np.cbrt(prop.area)
+        else:
+            _alpha = float(alpha)
+
+        center_transform = 1 / (1 + beta * _alpha * distance_to_center)
+        coords_z = coords[:, 0]
+        coords_x = coords[:, 1]
+        coords_y = coords[:, 2]
+        inner_distance[coords_z, coords_x, coords_y] = center_transform
+
+    if bins is None:
+        return inner_distance
+
+    # divide into bins
+    min_dist = np.amin(inner_distance.flatten())
+    max_dist = np.amax(inner_distance.flatten())
+    distance_bins = np.linspace(min_dist - eps,
+                                max_dist + eps,
+                                num=bins + 1)
+    inner_distance = np.digitize(inner_distance, distance_bins, right=True)
+    return inner_distance - 1  # minimum distance should be 0, not 1
+
+
+def inner_distance_transform_movie(mask, bins=None, erosion_width=None,
+                                   alpha=0.1, beta=1):
+    """Transform a label mask with an inner distance transform. Applies the
+    2D transform to each frame.
+
+    Args:
+        mask (numpy.array): A label mask (``y`` data).
+        bins (int): The number of transformed distance classes.
+        erosion_width (int): Number of pixels to erode edges of each labels.
+        alpha (float, str): Coefficent to reduce the magnitude of the distance
+            value. If "auto", determines ``alpha`` for each cell based on the
+            cell area.
+        beta (float): Scale parameter that is used when ``alpha`` is "auto".
+
+    Returns:
+        numpy.array: A mask of same shape as input mask,
+        with each label being a distance class from 1 to ``bins``.
+
+    Raises:
+        ValueError: ``alpha`` is a string but not set to "auto".
+    """
+    # Check input to alpha
+    if isinstance(alpha, str):
+        if alpha.lower() != 'auto':
+            raise ValueError('alpha must be set to "auto"')
+
+    inner_distances = []
+
+    for frame in range(mask.shape[0]):
+        mask_frame = mask[frame]
+
+        inner_distance = inner_distance_transform_2d(
+            mask_frame, bins=bins,
+            erosion_width=erosion_width,
+            alpha=alpha, beta=beta)
+
+        inner_distances.append(inner_distance)
+
+    inner_distances = np.stack(inner_distances, axis=0)
+
+    return inner_distances


### PR DESCRIPTION
- Created tensorflow-equivalent pytorch dataloaders for transforming input data for training
- Added transform_masks function (further cleaning required to remove unnecessary 3d and support)
- Changed imports to work for all train and evaluate scripts
- Moved all scripts to examples folder (until other folders are created)