### PR TITLE
Mesmer resize functions

### DIFF
--- a/torch_mesmer/applications.py
+++ b/torch_mesmer/applications.py
@@ -108,29 +108,6 @@ class Application:
     def predict(self, x):
         raise NotImplementedError
 
-    def _resize_input(self, image, image_mpp):
-        """Checks if there is a difference between image and model resolution
-        and resizes if they are different. Otherwise returns the unmodified
-        image.
-
-        Args:
-            image (numpy.array): Input image to resize.
-            image_mpp (float): Microns per pixel for the ``image``.
-
-        Returns:
-            numpy.array: Input image resized if necessary to match ``model_mpp``
-        """
-        # Don't scale the image if mpp is the same or not defined
-        if image_mpp not in {None, self.model_mpp}:
-            shape = image.shape
-            scale_factor = image_mpp / self.model_mpp
-            new_shape = (int(shape[1] * scale_factor),
-                         int(shape[2] * scale_factor))
-            image = resize(image, new_shape, data_format='channels_last')
-            self.logger.debug('Resized input from %s to %s', shape, new_shape)
-
-        return image
-
     def _preprocess(self, image, **kwargs):
         """Preprocess ``image`` if ``preprocessing_fn`` is defined.
         Otherwise return ``image`` unmodified.
@@ -281,44 +258,6 @@ class Application:
         else:
             return output_images
 
-    def _resize_output(self, image, original_shape):
-        """Rescales input if the shape does not match the original shape
-        excluding the batch and channel dimensions.
-
-        Args:
-            image (numpy.array): Image to be rescaled to original shape
-            original_shape (tuple): Shape of the original input image
-
-        Returns:
-            numpy.array: Rescaled image
-        """
-        if not isinstance(image, list):
-            image = [image]
-
-        for i in range(len(image)):
-            img = image[i]
-            # Compare x,y based on rank of image
-            if len(img.shape) == 4:
-                same = img.shape[1:-1] == original_shape[1:-1]
-            elif len(img.shape) == 3:
-                same = img.shape[1:] == original_shape[1:-1]
-            else:
-                same = img.shape == original_shape[1:-1]
-
-            # Resize if same is false
-            if not same:
-                # Resize function only takes the x,y dimensions for shape
-                new_shape = original_shape[1:-1]
-                img = resize(img, new_shape,
-                             data_format='channels_last',
-                             labeled_image=True)
-            image[i] = img
-
-        if len(image) == 1:
-            image = image[0]
-
-        return image
-
     def _batch_predict(self, tiles, batch_size):
         """Batch process tiles to generate model predictions.
 
@@ -449,18 +388,22 @@ class Application:
                              f'Input data only has {image.shape[-1]} channels')
 
         # Resize image, returns unmodified if appropriate
-        resized_image = self._resize_input(image, image_mpp)
+        resized_image = image
 
         # Generate model outputs
         output_images = self._run_model(
             image=resized_image, batch_size=batch_size,
             pad_mode=pad_mode, preprocess_kwargs=preprocess_kwargs
         )
+        print(output_images['whole-cell'][0].shape)
+        print(output_images['whole-cell'][1].shape)
 
         # Postprocess predictions to create label image
         label_image = self._postprocess(output_images, **postprocess_kwargs)
 
+        print(label_image.shape)
+
         # Resize label_image back to original resolution if necessary
-        label_image = self._resize_output(label_image, image.shape)
+        
 
         return label_image


### PR DESCRIPTION
Moved resize input and output functions from applications.py to mesmer.py
Found accommodations for list outputs that seem to be unnecessary for mesmer, so will test more and remove