### PR TITLE
Replace opencv dependency with headless version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "torchvision",
     "scipy",
     "scikit-image",
-    "opencv-python",
+    "opencv-python-headless",
 ]
 
 [[project.authors]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ torch
 torchvision
 scipy
 scikit-image
-opencv-python
+opencv-python-headless
 tqdm


### PR DESCRIPTION
The full package interferes with Qt bindings and has other nasty side-effects. Since we're only using opencv programatically (i.e. we don't need cv2 interactive viz) this should avoid those problems without sacrificing anything.