### PR TITLE
Remove print statements from code and test suite

### DIFF
--- a/torch_mesmer/backbone_utils.py
+++ b/torch_mesmer/backbone_utils.py
@@ -172,8 +172,6 @@ def get_backbone(backbone, input_tensor=None, input_shape=None,
     elif _backbone in resnet_backbones:
         model_cls = resnet_backbones[_backbone]
         if use_imagenet:
-            print("Using ImageNet")
-            
             # model_cls=resnet50(weights=ResNet50_Weights.DEFAULT)
             model_cls=resnet50(weights=ResNet50_Weights.IMAGENET1K_V2)
         else:

--- a/torch_mesmer/deep_watershed.py
+++ b/torch_mesmer/deep_watershed.py
@@ -1,8 +1,4 @@
 """Functions for pre- and post-processing image data"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import warnings
 
 import numpy as np

--- a/torch_mesmer/deep_watershed_test.py
+++ b/torch_mesmer/deep_watershed_test.py
@@ -1,8 +1,4 @@
 """Tests for post-processing functions"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 
 import pytest

--- a/torch_mesmer/mesmer.py
+++ b/torch_mesmer/mesmer.py
@@ -404,8 +404,6 @@ class Mesmer():
             #         "See e.g. https://github.com/pytorch/pytorch/issues/84936 for a discussion."
             #     )
 
-        print(f"using device: {device}")
-
         if model is None:
             raise Exception("Need to provide a model")
 

--- a/torch_mesmer/model_utils.py
+++ b/torch_mesmer/model_utils.py
@@ -15,7 +15,6 @@ def create_model(input_shape=(256, 256, 2), backbone="resnet50", lr=1e-4, device
         location=True,  # should always be true
         include_top=True,
     )
-    print("Model is using", device)
 
     loss = []
     model = model.to(device)

--- a/torch_mesmer/toolbox_processing.py
+++ b/torch_mesmer/toolbox_processing.py
@@ -1,8 +1,4 @@
 """Functions for pre- and post-processing image data"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import logging
 
 import numpy as np

--- a/torch_mesmer/toolbox_utils.py
+++ b/torch_mesmer/toolbox_utils.py
@@ -1,8 +1,4 @@
 """Utility functions that may be used in other transforms."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import cv2
 from scipy.signal import windows

--- a/torch_mesmer/transform_utils.py
+++ b/torch_mesmer/transform_utils.py
@@ -38,13 +38,8 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
         ``[bg_cell_edge, cell_cell_edge, cell_interior, background]``.
     """
     if data_format is None:
-        print("Please provide a data format")
-        assert(False)
-
-    if data_format == 'channels_first':
-        channel_axis = 0
-    else:
-        channel_axis = -1
+        raise ValueError("Please provide a data format")
+    channel_axis = 0 if data_format == "channels_first" else -1
 
     # Detect the edges and interiors
     edge = find_boundaries(mask, mode='inner').astype('int')

--- a/torch_mesmer/transform_utils_test.py
+++ b/torch_mesmer/transform_utils_test.py
@@ -64,7 +64,6 @@ def test_pixelwise_transform_2d():
         img = np.squeeze(img)
         pw_img = pixelwise_transform(
             img, data_format='channels_last', separate_edge_classes=False)
-        print(pw_img)
         pw_img_dil = pixelwise_transform(
             img, dilation_radius=1,
             data_format='channels_last',
@@ -170,8 +169,6 @@ def test_outer_distance_transform_2d():
 
         bins = 3
         distance = outer_distance_transform_2d(img, bins=bins)
-        print(distance)
-        print(np.unique(distance))
         # np.testing.assert_equal(np.unique(distance), np.array([0, 1, 2]))
         np.testing.assert_equal(np.expand_dims(distance, axis=-1).shape,
                          img.shape)


### PR DESCRIPTION
There is sometimes conflicting information about model/device presented to the users based on info printed in various functions. I vote to remove all of these - we can always add back logging as needed.