### PR TITLE
Minor updates to Zarr access patterns.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scikit-image
 torch
 torchvision
 tqdm
-zarr
+zarr>2
 matplotlib
 seaborn
 networkx

--- a/torch_mesmer/eval.py
+++ b/torch_mesmer/eval.py
@@ -138,7 +138,9 @@ def main(device: str,
 
     X_test = z_test['X'][:]
     y_test = z_test['y'][:].astype(int)
-    mpps = z_test['meta']['pixel_size'][:]
+    # NOTE: Zarr doesn't support structured arrays - must be converted to numpy
+    # array explicitly before attempting to access fields
+    mpps = z_test['meta'][:]["pixel_size"]
 
     # Load model and application
     model = Mesmer(

--- a/torch_mesmer/preprocess.py
+++ b/torch_mesmer/preprocess.py
@@ -45,19 +45,17 @@ def convert_to_zarr(filename, out_dir=None):
     print(f"    Writing {split}.")
 
     # Store 'X' — chunked across C, H, W (one sample per chunk)
-    store.create_dataset(
+    store.create_array(
         "X",
         data=X,
         chunks=(1, C, H, W),  # chunk = one full image (all channels, full spatial dims)
-        dtype=X.dtype,
     )
 
     # Store 'y' — chunked across C, H, W (one sample per chunk)
-    store.create_dataset(
+    store.create_array(
         "y",
         data=y,
         chunks=(1, C, H, W),
-        dtype=y.dtype,
     )
 
     meta_dtype = np.dtype(
@@ -71,7 +69,7 @@ def convert_to_zarr(filename, out_dir=None):
     meta_ary["specimen"] = data["meta"][crop_val:, -1]
 
     # Store 'metadata' — no spatial chunking needed, one scalar per sample
-    store.create_dataset(
+    store.create_array(
         "meta",
         data=meta_ary,
     )


### PR DESCRIPTION
* Zarr3 doesn't support structured dtype access - convert to numpy array first
* Zarr3 doesn't have create_dataset, replace with create_array.

Also adds a lower-bound pin on the zarr dependency to ensure users can't get zarr v2.

With these changes, the evaluation loop should again be portable - a reminder of the recipe:
 - Download & unpack tissuenet in the canonical location (`$HOME/.deepcell`)
 - Install `torch-mesmer` and additional eval dependencies, e.g.
   ```bash
   python -m venv tm-eval-env
   source tm-eval-env/bin/activate
   pip install -r requirements.txt
   pip install -e .
   ```
 - Convert tissuenet to expected format: `python -m torch_mesmer.preprocess` (only need to do this once)
 - Run the evaluation on a selected model. Note - requires model weights:
   ```bash
   python -m torch_mesmer.eval --model-path "path/to/model/wts/to/be/evaluated.pth" --device "cuda"
   ```
   where the `--device` flag is a recognized [torch device](https://docs.pytorch.org/docs/stable/tensor_attributes.html#torch-device)