### PR TITLE
ENH: Explicitly set output_tile dtype to match input tiles.

### DIFF
--- a/torch_mesmer/mesmer.py
+++ b/torch_mesmer/mesmer.py
@@ -179,7 +179,10 @@ class Mesmer():
         # Tile images, raises error if the image is not 4d
         tiles, tiles_info = tile_input(image, pad_mode=pad_mode, model_image_shape=self.model_image_shape)
         B_tiles = tiles.shape[0]
-        output_tiles = np.zeros((B_tiles,) + (8,) + self.model_image_shape)
+        output_tiles = np.zeros(
+            (B_tiles,) + (8,) + self.model_image_shape,
+            dtype=tiles.dtype,
+        )
 
         for tile_batch_start in range(0, tiles.shape[0], batch_size):
             # Load only this batch to GPU


### PR DESCRIPTION
In practice moves the output_tiles from float64 to float32, which should help with memory footprint.

Has no practical effect on gh-52.