### PR TITLE
Default to deepcell access portal for model weights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Image Analysis',
 ]
 dependencies = [
+    "deepcell_auth@git+https://github.com/vanvalenlab/deepcell-auth.git",
     "ipython",
     "matplotlib",
     "opencv-python-headless",

--- a/torch_mesmer/eval.py
+++ b/torch_mesmer/eval.py
@@ -1,4 +1,3 @@
-import glob
 from pathlib import Path
 from datetime import datetime
 import zarr
@@ -104,9 +103,9 @@ def create_overlays(x, gt, pred):
 
 @click.option(
     '--model-path', 
-    default=None,
+    default= Path.home() / ".deepcell/models/mesmer/saved_model_best_dict.pth", 
     help="""Path to model. 
-            If unset, will use default DeepCell location (`~/.deepcell/models/torch_mesmer*.pth`)"""
+            If unset, will use default DeepCell location (`~/.deepcell/models/mesmer/saved_model_best_dict.pth`)"""
             )
 
 @click.option(
@@ -142,26 +141,6 @@ def main(device: str,
     # NOTE: Zarr doesn't support structured arrays - must be converted to numpy
     # array explicitly before attempting to access fields
     mpps = z_test['meta'][:]["pixel_size"]
-
-    # Choose default model if no model_path specified
-    if model_path is None:
-        canonical_location = Path.home() / ".deepcell/models"
-        # Search for torch-mesmer models at canonical location
-        model_paths = glob.glob(str(canonical_location / "torch-mesmer*"))
-        if len(model_paths) < 1:
-            raise FileNotFoundError(
-                "No torch-mesmer model weights found. The latest pre-trained weights\n"
-                "can be downloaded with:\n\n"
-                "  from deepcell_auth import download_torch_mesmer_model\n"
-                "  download_torch_mesmer_model()\n\n"
-                "Or, specify an exact path to the model weights you'd like to use.\n"
-            )
-        if len(model_paths) > 1:
-            raise ValueError(
-                f"More than one set of weights found at {canonical_location}.\n"
-                "Please specify the path to which weights you'd like to evaluate."
-            )
-        model_path = model_paths[0]
 
     # Load model and application
     model = Mesmer(

--- a/torch_mesmer/eval.py
+++ b/torch_mesmer/eval.py
@@ -1,3 +1,4 @@
+import glob
 from pathlib import Path
 from datetime import datetime
 import zarr
@@ -103,9 +104,9 @@ def create_overlays(x, gt, pred):
 
 @click.option(
     '--model-path', 
-    default= Path.home() / ".deepcell/models/mesmer/saved_model_best_dict.pth", 
+    default=None,
     help="""Path to model. 
-            If unset, will use default DeepCell location (`~/.deepcell/models/mesmer/saved_model_best_dict.pth`)"""
+            If unset, will use default DeepCell location (`~/.deepcell/models/torch_mesmer*.pth`)"""
             )
 
 @click.option(
@@ -141,6 +142,26 @@ def main(device: str,
     # NOTE: Zarr doesn't support structured arrays - must be converted to numpy
     # array explicitly before attempting to access fields
     mpps = z_test['meta'][:]["pixel_size"]
+
+    # Choose default model if no model_path specified
+    if model_path is None:
+        canonical_location = Path.home() / ".deepcell/models"
+        # Search for torch-mesmer models at canonical location
+        model_paths = glob.glob(str(canonical_location / "torch-mesmer*"))
+        if len(model_paths) < 1:
+            raise FileNotFoundError(
+                "No torch-mesmer model weights found. The latest pre-trained weights\n"
+                "can be downloaded with:\n\n"
+                "  from deepcell_auth import download_torch_mesmer_model\n"
+                "  download_torch_mesmer_model()\n\n"
+                "Or, specify an exact path to the model weights you'd like to use.\n"
+            )
+        if len(model_paths) > 1:
+            raise ValueError(
+                f"More than one set of weights found at {canonical_location}.\n"
+                "Please specify the path to which weights you'd like to evaluate."
+            )
+        model_path = model_paths[0]
 
     # Load model and application
     model = Mesmer(

--- a/torch_mesmer/mesmer.py
+++ b/torch_mesmer/mesmer.py
@@ -1,3 +1,5 @@
+import glob
+from pathlib import Path
 import torch
 torch.set_num_threads(24)
 
@@ -20,7 +22,10 @@ class Mesmer():
         """        
         Initializes a Panoptic network segmentation model using the following parameters.
         
-        :params model_path: the path to where the model weights are stored
+        :params model_path: the path to where the model weights are stored. If
+            not specified, the latest released model weights will be used. Note
+            that internet access and a valid `DEEPCELL_ACCESS_TOKEN` is required
+            to download the latest weights.
         :type model_path: str
         
         :params device: GPU where you would like to conduct inference. 
@@ -40,8 +45,16 @@ class Mesmer():
             self.device=device
 
         if model_path is None:
-            raise Exception("Please provide a path to the model checkpoint file.")
-        
+            from deepcell_auth import download_torch_mesmer_model
+
+            download_torch_mesmer_model()
+
+            canonical_path = Path.home() / ".deepcell/models"
+            # Use latest version
+            model_path = sorted(
+                glob.glob(str(canonical_path / "torch-mesmer*.pth"))
+            )[-1]
+
         print("Initializing model...")
         
         self.model = PanopticNet(


### PR DESCRIPTION
Integrates `deepcell_auth` into `torch-mesmer` for accessing pre-trained model weights.

There are many different ways this could be done, but I've decided to go with a relatively simple but flexible pattern.

Previously, `model_path` was a required argument to the Mesmer constructor. With this PR, the default behavior will change so that if `model_path` is None (the default) the constructor will reach out to the deepcell portal to verify (and download if necessary) the latest pretrained weights.

This pattern has the advantage that existing workflows (where `model_path` is explicitly specified) will continue to work without any change. Another advantage of this pattern is that it guarantees that users are always getting the latest model when running by default.

NOTE: this PR depends on vanvalenlab/deepcell-auth#7, so checking it out and testing locally won't work until that's merged (though you can install `deepcell-auth` from the PR branch separately for testing!)